### PR TITLE
feat: sample yelp results by term

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@ bin/
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Environment Files
+.env
+
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
 # yelp-roulette
+
 Simple app to randomly select a restaurant using the Yelp API
+
+## Usage
+
+```
+Randomly select a restaurant from the Yelp API
+
+Usage:
+  yelp-roulette [query] [flags]
+
+Flags:
+  -t, --access-token string   Yelp Developer API Access Token
+  -h, --help                  help for yelp-roulette
+  -l, --location string       Location to base search results off of (default "Santa Barbara, CA")
+      --open-now              Filters results based on if business is open now
+  -p, --price stringArray     Pricing levels to filter the search result with: 1 = $, 2 = $$, 3 = $$$, 4 = $$$$
+```
+
+The Access Token can also be configured by the environment variable `YELP_ROULETTE_ACCESS_TOKEN`
+
+### Filter by Location
+
+The Yelp API allows for fuzzy like searching of Businesses via geographic location terms (e.g. `Yosemite, CA`, `NYC`, `123 Main Street, Fake City, Fake State`).
+
+The location can be filtered by providing the `--location` flag
+
+```
+yelp-roulette dinner --location "Albequerque, NM"
+```
+
+### Filter by Price Options
+
+The Yelp API allows for limiting results based on price buckets.
+Multiple price options can be provided and will be concatenated together. For example,
+
+```
+yelp-roulette dinner --price 1 --price 2
+```
+
+will limit results to those that match either the `$` or `$$` pricing level.
+
+### Filter by Open Businesses
+
+By default, all businesses that match the search terms will be in
+sample pool for results. To restrict the sample pool to only those
+that are currently open, provide the `--open-now` flag.
+
+```
+yelp-roulette dinner --open-now
+```
+
+## Development
+
+Local development requires go1.19+. Follow these steps for local development:
+
+1. Pull the latest `main` source
+2. Create a new Feature Branch
+3. Make changes to the source code
+4. Run `make build` to build the `yelp-roulette` CLI
+5. Test your changes with `bin/yelp-roulette`

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "yelp-roulette [options] [query]",
+	Use:   "yelp-roulette [query]",
 	Short: "Randomly select a restaurant from the Yelp API",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -18,21 +18,41 @@ var rootCmd = &cobra.Command{
 			accessToken = os.Getenv("YELP_ROULETTE_ACCESS_TOKEN")
 		}
 
-		yelp.NewClient(yelp.ClientConfig{Context: context.Background(), AccessToken: accessToken})
+		client := yelp.NewClient(yelp.ClientConfig{Context: context.Background(), AccessToken: accessToken})
+		business, err := client.RandomBusiness(yelp.SearchRequest{
+			Term:     args[0],
+			Location: location,
+			OpenNow:  openNow,
+			Price:    price,
+		})
+		if err != nil {
+			fatalError(err)
+		}
+		fmt.Printf("%s - %s\n%s\n", business.Name, business.Price, business.URL)
 	},
 }
 
 var (
 	accessToken string
+	location    string
+	openNow     bool
+	price       []string
 )
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&accessToken, "access-token", "t", "", "Yelp Developer API Access Token")
+	rootCmd.Flags().StringVarP(&location, "location", "l", "Santa Barbara, CA", "Location to base search results off of")
+	rootCmd.Flags().BoolVarP(&openNow, "open-now", "", false, "Filters results based on if business is open now")
+	rootCmd.Flags().StringArrayVarP(&price, "price", "p", []string{}, "Pricing levels to filter the search result with: 1 = $, 2 = $$, 3 = $$$, 4 = $$$$")
 }
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		fatalError(err)
 	}
+}
+
+func fatalError(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
 }

--- a/pkg/yelp/client.go
+++ b/pkg/yelp/client.go
@@ -1,20 +1,14 @@
 package yelp
 
 import (
-	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
 
 	"github.com/shurcooL/graphql"
 	"golang.org/x/oauth2"
 )
-
-type ClientConfig struct {
-	Context     context.Context
-	AccessToken string
-}
-
-type Client struct {
-	client *graphql.Client
-}
 
 const endpoint = "https://api.yelp.com/v3/graphql"
 
@@ -26,5 +20,37 @@ func NewClient(config ClientConfig) *Client {
 	httpClient := oauth2.NewClient(config.Context, src)
 	client := graphql.NewClient(endpoint, httpClient)
 
-	return &Client{client: client}
+	return &Client{context: config.Context, client: client}
+}
+
+// init sets initial values for variables used in the function.
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// Search returns all businesses matching the SearchRequest terms up to a provided maximum sample size
+func (c *Client) Search(params SearchRequest) ([]YelpBusiness, error) {
+	variables := map[string]interface{}{
+		"term":     graphql.String(params.Term),
+		"location": graphql.String(params.Location),
+		"limit":    graphql.Int(50),
+		"offset":   graphql.Int(0),
+		"openNow":  graphql.Boolean(params.OpenNow),
+		"price":    graphql.String(strings.Join(params.Price, ", ")),
+	}
+	query := searchQuery{}
+	if err := c.client.Query(c.context, &query, variables); err != nil {
+		return []YelpBusiness{}, fmt.Errorf("executing query: %w", err)
+	}
+
+	return query.Search.Business, nil
+}
+
+func (c *Client) RandomBusiness(params SearchRequest) (YelpBusiness, error) {
+	businesses, err := c.Search(params)
+	if err != nil {
+		return YelpBusiness{}, err
+	}
+
+	return businesses[rand.Intn(len(businesses))], nil
 }

--- a/pkg/yelp/types.go
+++ b/pkg/yelp/types.go
@@ -1,0 +1,42 @@
+package yelp
+
+import (
+	"context"
+
+	"github.com/shurcooL/graphql"
+)
+
+// ClientConfig provides configuration for a new Yelp Client
+type ClientConfig struct {
+	Context     context.Context
+	AccessToken string
+}
+
+// Client provides a wrapped to the Yelp GraphQL API
+type Client struct {
+	context context.Context
+	client  *graphql.Client
+}
+
+// SearchRequest represents the parameters the Yelp Search request
+type SearchRequest struct {
+	Term     string
+	Location string
+	OpenNow  bool
+	Price    []string
+}
+
+type searchQuery struct {
+	Search struct {
+		Total    graphql.Int
+		Business []YelpBusiness
+	} `graphql:"search(term: $term, location: $location, limit: $limit, offset: $offset, price: $price, open_now: $openNow)"`
+}
+
+// YelpBusiness represents a Yelp Business returned from the Search query
+type YelpBusiness struct {
+	ID    graphql.ID
+	Name  graphql.String
+	URL   graphql.String
+	Price graphql.String
+}


### PR DESCRIPTION
adds yelp client functions to query the [Yelp Search GraphQL API](https://www.yelp.com/developers/graphql/query/search). Adds a `RandomBusiness` function as well to pick a business at random.

`yelp-roulette [search-term]` will now return a random Business for the provided location.