### PR TITLE
feat: within support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,23 @@ module github.com/alecjacobs5401/yelp-roulette
 go 1.19
 
 require (
+	github.com/martinlindhe/unit v0.0.0-20220817221856-f7b595b5f97e
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/martinlindhe/unit v0.0.0-20220817221856-f7b595b5f97e h1:9irq8AxmCM4rT4f0U35hXB/rFY/Tb2/YwnMj06EJMzw=
+github.com/martinlindhe/unit v0.0.0-20220817221856-f7b595b5f97e/go.mod h1:8QbxAolnDKw/JhUJMU80MRjHjEs0tLwkjZAPrTn+xLA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -23,6 +25,7 @@ github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJ
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -45,6 +48,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -1,0 +1,31 @@
+package convert
+
+import (
+	"fmt"
+
+	"github.com/martinlindhe/unit"
+)
+
+var unitMap = map[string]unit.Length{
+	"mi":         unit.Mile,
+	"mile":       unit.Mile,
+	"miles":      unit.Mile,
+	"km":         unit.Kilometer,
+	"kilometer":  unit.Kilometer,
+	"kilometers": unit.Kilometer,
+	"kilometre":  unit.Kilometer,
+	"kilometres": unit.Kilometer,
+	"m":          unit.Meter,
+	"meter":      unit.Meter,
+	"meters":     unit.Meter,
+	"metre":      unit.Meter,
+	"metres":     unit.Meter,
+}
+
+func ToMeters(value float64, originalUnit string) (float64, error) {
+	lengthUnit := unitMap[originalUnit]
+	if lengthUnit == 0 {
+		return 0, fmt.Errorf("unknown unit provided: %#v", originalUnit)
+	}
+	return (unit.Length(value) * lengthUnit).Meters(), nil
+}

--- a/pkg/convert/convert_test.go
+++ b/pkg/convert/convert_test.go
@@ -1,0 +1,115 @@
+package convert
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToMeters(t *testing.T) {
+	testCases := []struct {
+		name          string
+		value         float64
+		originalUnit  string
+		expectedValue float64
+		expectedError error
+	}{
+		{
+			name:          "from miles",
+			value:         25,
+			originalUnit:  "miles",
+			expectedValue: 40233.60,
+		},
+		{
+			name:          "from mile",
+			value:         10,
+			originalUnit:  "miles",
+			expectedValue: 16093.44,
+		},
+		{
+			name:          "from mi",
+			value:         15,
+			originalUnit:  "mi",
+			expectedValue: 24140.16,
+		},
+		{
+			name:          "from km",
+			value:         25,
+			originalUnit:  "km",
+			expectedValue: 25000,
+		},
+		{
+			name:          "from kilometer",
+			value:         25,
+			originalUnit:  "kilometer",
+			expectedValue: 25000,
+		},
+		{
+			name:          "from kilometre",
+			value:         25,
+			originalUnit:  "kilometre",
+			expectedValue: 25000,
+		},
+		{
+			name:          "from kilometers",
+			value:         10,
+			originalUnit:  "kilometers",
+			expectedValue: 10000,
+		},
+		{
+			name:          "from kilometres",
+			value:         15,
+			originalUnit:  "kilometres",
+			expectedValue: 15000,
+		},
+		{
+			name:          "from m",
+			value:         25,
+			originalUnit:  "m",
+			expectedValue: 25,
+		},
+		{
+			name:          "from meter",
+			value:         25,
+			originalUnit:  "meter",
+			expectedValue: 25,
+		},
+		{
+			name:          "from metre",
+			value:         25,
+			originalUnit:  "metre",
+			expectedValue: 25,
+		},
+		{
+			name:          "from meters",
+			value:         10,
+			originalUnit:  "meters",
+			expectedValue: 10,
+		},
+		{
+			name:          "from metres",
+			value:         15,
+			originalUnit:  "metres",
+			expectedValue: 15,
+		},
+		{
+			name:          "from unknown unit",
+			value:         15,
+			originalUnit:  "random-unit",
+			expectedError: errors.New("unknown unit provided: \"random-unit\""),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			value, err := ToMeters(testCase.value, testCase.originalUnit)
+			if testCase.expectedError != nil && assert.Error(t, err) {
+				assert.Equal(t, err, testCase.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, testCase.expectedValue, value)
+			}
+		})
+	}
+}

--- a/pkg/yelp/client.go
+++ b/pkg/yelp/client.go
@@ -42,6 +42,7 @@ func (c *Client) Search(params SearchRequest) ([]YelpBusiness, error) {
 		"offset":   graphql.Int(resultsSize),
 		"openNow":  graphql.Boolean(params.OpenNow),
 		"price":    graphql.String(strings.Join(params.Price, ", ")),
+		"radius":   graphql.Float(params.Within),
 	}
 
 	businesses := []YelpBusiness{}

--- a/pkg/yelp/request.go
+++ b/pkg/yelp/request.go
@@ -1,0 +1,128 @@
+package yelp
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/alecjacobs5401/yelp-roulette/pkg/convert"
+)
+
+var withinRegex = regexp.MustCompile(`(\d+)(\w*)`)
+
+// TODO: this should be its own package with better type handling for parsing query strings
+// ParseRequest takes a message and parses out the text into a SearchRequest
+func ParseRequest(body string) (SearchRequest, error) {
+	tokens := strings.Split(body, " ")
+
+	inIndex := -1
+	openIndex := -1
+	withinIndex := -1
+	priceIndices := []int{}
+	priceLevels := []string{}
+	locationTokens := []string{}
+	termTokens := []string{}
+	within := 0
+
+	for index, token := range tokens {
+		switch strings.ToLower(token) {
+		case "in":
+			inIndex = index
+		case "open":
+			openIndex = index
+		case "within":
+			withinIndex = index
+		case "$", "$$", "$$$", "$$$$":
+			priceIndices = append(priceIndices, index)
+			priceLevels = append(priceLevels, fmt.Sprint(strings.Count(token, "$")))
+		default:
+			if inIndex >= 0 || withinIndex >= 0 {
+				continue
+			} else {
+				termTokens = append(termTokens, token)
+			}
+		}
+	}
+
+	tokensLength := len(tokens)
+	lastTokenIndex := tokensLength - 1
+	indices := append(priceIndices, inIndex, withinIndex, openIndex, tokensLength)
+	sort.Ints(indices)
+
+	if inIndex >= 0 {
+		index := indexOf(indices, inIndex)
+		if indices[index] >= lastTokenIndex {
+			return SearchRequest{}, errors.New("no location provided")
+		}
+		nextIndex := indices[index+1]
+		locationTokens = tokens[inIndex+1 : nextIndex]
+		if len(locationTokens) == 0 {
+			return SearchRequest{}, errors.New("no location provided")
+		}
+	}
+
+	if withinIndex >= 0 {
+		index := indexOf(indices, withinIndex)
+		if indices[index] >= lastTokenIndex {
+			return SearchRequest{}, errors.New("invalid within options provided")
+		}
+		nextIndex := indices[index+1]
+		withinTokens := tokens[withinIndex+1 : nextIndex]
+
+		switch len(withinTokens) {
+		case 1:
+			matches := withinRegex.FindStringSubmatch(withinTokens[0])
+			if matches == nil {
+				return SearchRequest{}, errors.New("invalid value provided for within distance")
+			}
+			value, _ := strconv.ParseFloat(matches[1], 64)
+			unit := matches[2]
+			if unit == "" {
+				within = int(value)
+			} else {
+				converted, err := convert.ToMeters(value, strings.ToLower(matches[2]))
+				if err != nil {
+					return SearchRequest{}, err
+				}
+				within = int(converted)
+			}
+		case 2:
+			value, err := strconv.ParseFloat(withinTokens[0], 64)
+			if err != nil {
+				return SearchRequest{}, errors.New("invalid value provided for within distance")
+			}
+			converted, err := convert.ToMeters(value, strings.ToLower(withinTokens[1]))
+			if err != nil {
+				return SearchRequest{}, err
+			}
+			within = int(converted)
+		default:
+			return SearchRequest{}, errors.New("invalid within options provided")
+		}
+	}
+
+	return SearchRequest{
+		Term:     strings.Join(termTokens, " "),
+		Location: strings.Join(locationTokens, " "),
+		OpenNow:  openIndex >= 0,
+		Price:    priceLevels,
+		Within:   within,
+	}, nil
+}
+
+// currently assumes sorted array
+func indexOf(items []int, value int) int {
+	for index, item := range items {
+		if item == value {
+			return index
+		}
+
+		if item > value {
+			return -1
+		}
+	}
+	return -1
+}

--- a/pkg/yelp/request_test.go
+++ b/pkg/yelp/request_test.go
@@ -1,0 +1,230 @@
+package yelp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRequest(t *testing.T) {
+	testCases := []struct {
+		name            string
+		message         string
+		expectedRequest SearchRequest
+		expectedError   error
+	}{
+		{
+			name:    "search term only",
+			message: "dinner",
+			expectedRequest: SearchRequest{
+				Term:  "dinner",
+				Price: []string{},
+			},
+		},
+		{
+			name:    "single value location only",
+			message: "in NYC",
+			expectedRequest: SearchRequest{
+				Location: "NYC",
+				Price:    []string{},
+			},
+		},
+		{
+			name:    "multi value location only",
+			message: "in Santa Barbara, CA",
+			expectedRequest: SearchRequest{
+				Location: "Santa Barbara, CA",
+				Price:    []string{},
+			},
+		},
+		{
+			name:    "$ only",
+			message: "$",
+			expectedRequest: SearchRequest{
+				Price: []string{"1"},
+			},
+		},
+		{
+			name:    "$$ only",
+			message: "$$",
+			expectedRequest: SearchRequest{
+				Price: []string{"2"},
+			},
+		},
+		{
+			name:    "$$$ only",
+			message: "$$$",
+			expectedRequest: SearchRequest{
+				Price: []string{"3"},
+			},
+		},
+		{
+			name:    "$$$$ only",
+			message: "$$$$",
+			expectedRequest: SearchRequest{
+				Price: []string{"4"},
+			},
+		},
+		{
+			name:    "with open only",
+			message: "open",
+			expectedRequest: SearchRequest{
+				OpenNow: true,
+				Price:   []string{},
+			},
+		},
+		{
+			name:    "with within only with space between length and unit",
+			message: "within 10 mi",
+			expectedRequest: SearchRequest{
+				Within: 16093,
+				Price:  []string{},
+			},
+		},
+		{
+			name:    "with within that has capital units",
+			message: "within 10 MI",
+			expectedRequest: SearchRequest{
+				Within: 16093,
+				Price:  []string{},
+			},
+		},
+		{
+			name:    "with within that has capital units no space",
+			message: "within 10MI",
+			expectedRequest: SearchRequest{
+				Within: 16093,
+				Price:  []string{},
+			},
+		},
+		{
+			name:    "with within only with no space between length and unit",
+			message: "within 1000m",
+			expectedRequest: SearchRequest{
+				Within: 1000,
+				Price:  []string{},
+			},
+		},
+		{
+			name:    "with within only with value",
+			message: "within 1500",
+			expectedRequest: SearchRequest{
+				Within: 1500,
+				Price:  []string{},
+			},
+		},
+		{
+			name:          "with invalid within value",
+			message:       "within distance",
+			expectedError: errors.New("invalid value provided for within distance"),
+		},
+		{
+			name:    "with term and location",
+			message: "dinner in NYC",
+			expectedRequest: SearchRequest{
+				Term:     "dinner",
+				Location: "NYC",
+				Price:    []string{},
+			},
+		},
+		{
+			name:    "with term and long location",
+			message: "dinner in Santa Barbara, CA",
+			expectedRequest: SearchRequest{
+				Term:     "dinner",
+				Location: "Santa Barbara, CA",
+				Price:    []string{},
+			},
+		},
+		{
+			name:    "with term, long location, and price options",
+			message: "dinner in Santa Barbara, CA $ $$$",
+			expectedRequest: SearchRequest{
+				Term:     "dinner",
+				Location: "Santa Barbara, CA",
+				Price:    []string{"1", "3"},
+			},
+		},
+		{
+			name:    "with term, long location, price options, and open",
+			message: "dinner in Santa Barbara, CA $ open $$$ $$",
+			expectedRequest: SearchRequest{
+				Term:     "dinner",
+				Location: "Santa Barbara, CA",
+				OpenNow:  true,
+				Price:    []string{"1", "3", "2"},
+			},
+		},
+		{
+			name:    "with term, long location, price options, and open",
+			message: "dinner in Santa Barbara, CA $ open $$$ $$",
+			expectedRequest: SearchRequest{
+				Term:     "dinner",
+				Location: "Santa Barbara, CA",
+				OpenNow:  true,
+				Price:    []string{"1", "3", "2"},
+			},
+		},
+		{
+			name:    "with term, long location, price options, open, and within",
+			message: "dinner in Santa Barbara, CA $ open $$$ $$ within 10mi",
+			expectedRequest: SearchRequest{
+				Term:     "dinner",
+				Location: "Santa Barbara, CA",
+				OpenNow:  true,
+				Price:    []string{"1", "3", "2"},
+				Within:   16093,
+			},
+		},
+		{
+			name:    "with within before in",
+			message: "dinner within 1000m in Santa Barbara, CA $ open $$$ $$",
+			expectedRequest: SearchRequest{
+				Term:     "dinner",
+				Location: "Santa Barbara, CA",
+				OpenNow:  true,
+				Price:    []string{"1", "3", "2"},
+				Within:   1000,
+			},
+		},
+		{
+			name:          "with in provided without location at end of query",
+			message:       "dinner in",
+			expectedError: errors.New("no location provided"),
+		},
+		{
+			name:          "with in provided without location",
+			message:       "dinner in $ $$ open",
+			expectedError: errors.New("no location provided"),
+		},
+		{
+			name:          "with within provided without value at end of query",
+			message:       "dinner within",
+			expectedError: errors.New("invalid within options provided"),
+		},
+		{
+			name:          "with within provided without value",
+			message:       "dinner within $ $$ open",
+			expectedError: errors.New("invalid within options provided"),
+		},
+		{
+			name:          "with within provided without value",
+			message:       "dinner within $ $$ open",
+			expectedError: errors.New("invalid within options provided"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			request, err := ParseRequest(testCase.message)
+
+			if testCase.expectedError != nil && assert.Error(t, err) {
+				assert.Equal(t, testCase.expectedError, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, testCase.expectedRequest, request)
+			}
+		})
+	}
+}

--- a/pkg/yelp/types.go
+++ b/pkg/yelp/types.go
@@ -25,13 +25,14 @@ type SearchRequest struct {
 	OpenNow       bool
 	Price         []string
 	MaxSampleSize int
+	Within        int
 }
 
 type searchQuery struct {
 	Search struct {
 		Total    graphql.Int
 		Business []YelpBusiness
-	} `graphql:"search(term: $term, location: $location, limit: $limit, offset: $offset, price: $price, open_now: $openNow)"`
+	} `graphql:"search(term: $term, location: $location, limit: $limit, offset: $offset, price: $price, open_now: $openNow, radius: $radius)"`
 }
 
 // YelpBusiness represents a Yelp Business returned from the Search query


### PR DESCRIPTION
This PR is a mish-mash of a bunch of things that I should I have split into other PRs, but I kept unraveling and discovering improvements for things as I went.

### In This PR
* adds the `convert` package which takes in a distance and unit and coverts to meters
* adds `yelp.ParseRequest` to move that logic out of `main.go`
* adds `within` keyword support to help limit search results to a refined radius